### PR TITLE
Fix the bug for loading textContent

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -23,7 +23,7 @@ async function fetchArticle() {
         const article = response.data.content;
         articleTitle = article.title;
 
-        articleTitleElement.textContent = article.title;
+        articleTitleElement.childNodes[0].textContent = article.title;
 
         const articleContent = article.content.replace(/\n/g, '<br>');
         contentElement.innerHTML = `


### PR DESCRIPTION
HTML template Structure:
```
<div>Article Content
  <div id="contentLoading"></div>
</div>
```

When you update the textContent of the parent div, the child div will also be overwritten, which caused the null object error at line 19 of script.js. That was the root cause of the infinite spinning when loading different articles.