### PR TITLE
Remove vulnerable unused LangSmith dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,10 +39,6 @@ Jinja2==3.1.4
 joblib==1.4.2
 jsonpatch==1.33
 jsonpointer==3.0.0
-langchain-core==0.2.29
-langchain-text-splitters==0.2.2
-langchain-openai==0.1.22
-langsmith==0.1.98
 llama-index-core==0.12.25
 llama-index-llms-openai==0.2.4
 llama-index-embeddings-openai==0.2.4


### PR DESCRIPTION
## Summary

- remove the vulnerable `langsmith==0.1.98` pin affected by GHSA-f4xh-w4cj-qxq8
- remove the associated unused LangChain dependency pins
- avoid a risky coordinated LangChain/OpenAI major-version upgrade because the repository does not import LangChain or LangSmith

## Validation

- repository-wide import scan found no LangChain or LangSmith imports
- `git diff --check` passed
- Python compilation passed for the application, utilities, and tests
- test execution was unavailable in the inspection environment because `pytest` was not installed

No application code is changed.